### PR TITLE
fix: broken deployment and destroy workflows 

### DIFF
--- a/.github/workflows/terraform-deploy.yaml
+++ b/.github/workflows/terraform-deploy.yaml
@@ -18,7 +18,7 @@ jobs:
     name: Deploy
     uses: subhamay-bhattacharyya-gha/tf-deploy-multi-reusable-wf/.github/workflows/terraform-deploy.yaml@feature/GHA-0019-add-platform-based-multi
     with:
-      cloud-provider: platform
+      cloud-provider: snowflake
       tflint-ver: ${{ vars.TF_LINT_VER }}
       backend-type: remote
       aws-region: ${{ vars.AWS_REGION }}

--- a/.github/workflows/terraform-destroy.yaml
+++ b/.github/workflows/terraform-destroy.yaml
@@ -18,7 +18,7 @@ jobs:
     name: Destroy Platform (AWS + Snowflake)
     uses: subhamay-bhattacharyya-gha/terraform-destroy-wf/.github/workflows/terraform-destroy.yaml@feature/GHA-0032-add-platform-based-multi
     with:
-      cloud-provider: platform
+      cloud-provider: snowflake
       backend-type: remote
       aws-region: ${{ vars.AWS_REGION }}
       snowflake-user: ${{ vars.SNOWFLAKE_USER }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,15 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Miscellaneous Tasks
+
+- Update cloud provider to snowflake in deployment workflows
+
+## [Rel-001-20260226174419] - 2026-02-26
+
 ### Documentation
 
+- Update CHANGELOG.md [skip ci]
 - Update CHANGELOG.md [skip ci]
 
 ### Features


### PR DESCRIPTION
This pull request updates the deployment and destroy workflows to use Snowflake as the cloud provider instead of Platform. The change is documented in the changelog and affects the GitHub Actions workflows for Terraform operations.

Updates to deployment and destroy workflows:

* [`.github/workflows/terraform-deploy.yaml`](diffhunk://#diff-583ec4325a1187233bbe2e4446cd871f1131e428125c56cae644803673fb60afL21-R21): Changed the `cloud-provider` input from `platform` to `snowflake` for the deploy workflow.
* [`.github/workflows/terraform-destroy.yaml`](diffhunk://#diff-530bc4b4a0f81d207c4a26b754de9ff0905e2d9f2a144ade59e7520f8c873438L21-R21): Changed the `cloud-provider` input from `platform` to `snowflake` for the destroy workflow.

Documentation:

* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR7-R15): Added a miscellaneous task entry documenting the update of the cloud provider to Snowflake in deployment workflows.